### PR TITLE
Add options for PubID output (date and language)

### DIFF
--- a/lib/pubid/iso/identifier/french.rb
+++ b/lib/pubid/iso/identifier/french.rb
@@ -1,8 +1,9 @@
 module Pubid::Iso
   class French < Identifier
-    def identifier
+    def identifier(with_date, with_language_code)
       if @type == "Guide"
-        "Guide #{originator}#{stage} #{number}#{part}#{iteration}#{year}#{edition}#{supplements}#{language}"
+        "Guide #{originator}#{stage} #{number}#{part}#{iteration}"\
+          "#{with_date && year || ''}#{edition}#{supplements}#{language(with_language_code)}"
       else
         super
       end

--- a/lib/pubid/iso/identifier/russian.rb
+++ b/lib/pubid/iso/identifier/russian.rb
@@ -17,9 +17,10 @@ module Pubid::Iso
              "ISP" => "ИСП",
     }.freeze
 
-    def identifier
+    def identifier(with_date, with_language_code)
       if @type == "Guide"
-        "Руководство #{originator}#{stage} #{number}#{part}#{iteration}#{year}#{edition}#{supplements}#{language}"
+        "Руководство #{originator}#{stage} #{number}#{part}#{iteration}"\
+          "#{with_date && year || ''}#{edition}#{supplements}#{language(with_language_code)}"
       else
         super
       end

--- a/spec/pubid_iso/identifier_spec.rb
+++ b/spec/pubid_iso/identifier_spec.rb
@@ -341,12 +341,22 @@ RSpec.describe Pubid::Iso::Identifier do
   context "ISO/IEC 17025:2005/Cor.1:2006(fr)" do
     let(:original) { "ISO/IEC 17025:2005/Cor.1:2006(fr)" }
     let(:pubid) { "ISO/IEC 17025:2005/Cor 1:2006(fr)" }
+    let(:pubid_without_date) { "ISO/IEC 17025/Cor 1:2006(fr)" }
+    let(:pubid_single_letter_language) { "ISO/IEC 17025:2005/Cor 1:2006(F)" }
     let(:french_pubid) { "ISO/CEI 17025:2005/Cor.1:2006(fr)" }
     let(:urn) { "urn:iso:std:iso-iec:17025:cor:2006:v1:fr" }
 
     it_behaves_like "converts pubid to urn"
     it_behaves_like "converts pubid to pubid"
     it_behaves_like "converts pubid to french pubid"
+
+    it "converts to pubid without date" do
+      expect(subject.to_s(with_date: false)).to eq(pubid_without_date)
+    end
+
+    it "converts to pubid with single letter language code" do
+      expect(subject.to_s(with_language_code: :single)).to eq(pubid_single_letter_language)
+    end
   end
 
   context "ISO 5537|IDF 26" do


### PR DESCRIPTION
Adding options for PubID output without date and options for languages output (single letter or ISO code).

closes #7 