### PR TITLE
Add test for having part number without dash

### DIFF
--- a/spec/pubid_iso/identifier_spec.rb
+++ b/spec/pubid_iso/identifier_spec.rb
@@ -378,6 +378,10 @@ RSpec.describe Pubid::Iso::Identifier do
 
     it_behaves_like "converts pubid to urn"
     it_behaves_like "converts pubid to pubid"
+
+    it "returns part without dash" do
+      expect(subject.part).to eq("4")
+    end
   end
 
   context "ISO/IEC 17025:2005/Cor.1:2006(fr)" do


### PR DESCRIPTION
closes #62 
I believe it was fixed during fixing #54, but good to double-check that.