### PR TITLE
Do not include "IS" stage for amendments and corrigendums in generated PubID

### DIFF
--- a/lib/pubid/iso/supplement.rb
+++ b/lib/pubid/iso/supplement.rb
@@ -20,7 +20,7 @@ module Pubid::Iso
     end
 
     def render_pubid_stage
-      ((@stage && @stage.abbr) || "")
+      ((@stage && @stage.abbr != "IS" && @stage.abbr) || "")
     end
 
     def render_urn_stage

--- a/spec/pubid_iso/identifier_spec.rb
+++ b/spec/pubid_iso/identifier_spec.rb
@@ -774,6 +774,31 @@ module Pubid::Iso
         end
       end
 
+      context "when create document with amendment and stage IS" do
+        let(:params) do
+          { year: 1999,
+            amendments: [Pubid::Iso::Amendment.new(number: 1, year: 2017,
+                                                   stage: Stage.new(abbr: "IS"))] }
+        end
+
+        it "should not render IS stage" do
+          expect(subject.to_s).to eq("ISO 123:1999/Amd 1:2017")
+        end
+      end
+
+      context "when create document with corrigendum and stage IS" do
+        let(:params) do
+          { year: 1999,
+            corrigendums: [Pubid::Iso::Corrigendum.new(number: 1, year: 2017,
+                                                     stage: Stage.new(abbr: "IS"))] }
+        end
+
+        it "should not render IS stage" do
+          expect(subject.to_s).to eq("ISO 123:1999/Cor 1:2017")
+        end
+      end
+
+
       context "when have DIR parameter" do
         context "when DIR true" do
           let(:params) { { dir: true } }


### PR DESCRIPTION
closes #81 