### PR TITLE
Add stage comparator

### DIFF
--- a/lib/pubid/iso/stage.rb
+++ b/lib/pubid/iso/stage.rb
@@ -68,7 +68,7 @@ module Pubid::Iso
 
     # Compares one stage with another
     def ==(other)
-      other.harmonized_code == harmonized_code
+      other&.harmonized_code == harmonized_code
     end
   end
 end

--- a/lib/pubid/iso/stage.rb
+++ b/lib/pubid/iso/stage.rb
@@ -65,5 +65,10 @@ module Pubid::Iso
         Stage.new(abbr: stage)
       end
     end
+
+    # Compares one stage with another
+    def ==(other)
+      other.harmonized_code == harmonized_code
+    end
   end
 end

--- a/spec/pubid_iso/stage_spec.rb
+++ b/spec/pubid_iso/stage_spec.rb
@@ -112,4 +112,34 @@ RSpec.describe Pubid::Iso::Stage do
       expect(subject.harmonized_code).to eq(harmonized_code)
     end
   end
+
+  describe "#==" do
+    subject do
+      first_stage == second_stage
+    end
+
+    context "when have the same harmonized_code" do
+      let(:first_stage) do
+        described_class.new(harmonized_code: "50.00")
+      end
+      let(:second_stage) do
+        described_class.new(harmonized_code: "50.00")
+      end
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "when have the different harmonized_code" do
+      let(:first_stage) do
+        described_class.new(harmonized_code: "50.00")
+      end
+      let(:second_stage) do
+        described_class.new(harmonized_code: "20.00")
+      end
+
+      it { is_expected.to be_falsey }
+    end
+
+
+  end
 end

--- a/spec/pubid_iso/supplemnent_spec.rb
+++ b/spec/pubid_iso/supplemnent_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Pubid::Iso::Supplement do
     context "when query with stage" do
       let(:first_supplement_stage) { Pubid::Iso::Stage.new(abbr: :CD) }
 
-      context "different stage in results" do
+      context "different stage" do
         let(:second_supplement_stage) { Pubid::Iso::Stage.new(abbr: :PWI) }
 
         it { is_expected.to be_falsey }
@@ -67,6 +67,12 @@ RSpec.describe Pubid::Iso::Supplement do
 
       context "no stage in results" do
         it { is_expected.to be_falsey }
+      end
+
+      context "the same stage" do
+        let(:second_supplement_stage) { Pubid::Iso::Stage.new(abbr: :CD) }
+
+        it { is_expected.to be_truthy }
       end
     end
 

--- a/spec/pubid_iso/supplemnent_spec.rb
+++ b/spec/pubid_iso/supplemnent_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Pubid::Iso::Supplement do
         it { is_expected.to be_falsey }
       end
 
-      context "no stage in results" do
+      context "when the second stage is nil" do
         it { is_expected.to be_falsey }
       end
 


### PR DESCRIPTION
related to #117 

I found after implementing stage as separate class we didn't implement comparator, so results pubid.stage == another_pubid.stage returns false when stages are different objects even if they have the same stage codes.
This pull request fixes this issue