### PR TITLE
Add support for legacy "R" identifier type

### DIFF
--- a/lib/pubid/iso/transformer.rb
+++ b/lib/pubid/iso/transformer.rb
@@ -87,14 +87,14 @@ module Pubid::Iso
                           :ts
                         when "ТО", "TR"
                           :tr
-                        when "Directives Part", "Directives, Part", "Directives,"
+                        when "Directives Part", "Directives, Part", "Directives,", "DIR"
                           :dir
                         when "PAS"
                           :pas
                         when "DPAS"
                           :dpas
-                        when "DIR"
-                          :dir
+                        when "R"
+                          :r
                         else
                           type
                         end) }

--- a/lib/pubid/iso/type.rb
+++ b/lib/pubid/iso/type.rb
@@ -41,6 +41,10 @@ module Pubid::Iso
       amd: {
         short: "Amd",
       },
+      r: {
+        long: "Recommendation",
+        short: "R",
+      },
     }.freeze
 
     # Create new type
@@ -64,6 +68,8 @@ module Pubid::Iso
 
     def ==(other)
       return type == other if other.is_a?(Symbol)
+
+      return false if other.nil?
 
       type == other.type
     end

--- a/spec/pubid_iso/identifier/identifier_spec.rb
+++ b/spec/pubid_iso/identifier/identifier_spec.rb
@@ -614,6 +614,12 @@ module Pubid::Iso
       it_behaves_like "converts pubid to urn"
     end
 
+    context "ISO/R 125:1966" do
+      let(:pubid) { "ISO/R 125:1966" }
+
+      it_behaves_like "converts pubid to pubid"
+    end
+
     describe "#parse_from_title" do
       subject { described_class.parse_from_title(title) }
       let(:title) { "#{pubid} Geographic information — Metadata — Part 1: Fundamentals" }


### PR DESCRIPTION
related to #151 
Without this `relaton-iso` tests produces an error because going through hit with identifier "ISO/R 125:1966"