### PR TITLE
Fix Base#typed_stage_name and typed_stage_abbrev output for identifiers without stage defined

### DIFF
--- a/lib/pubid/iso/identifier/base.rb
+++ b/lib/pubid/iso/identifier/base.rb
@@ -337,7 +337,7 @@ module Pubid::Iso
         if self.class::TYPED_STAGES.key?(typed_stage)
           self.class::TYPED_STAGES[typed_stage][:abbr]
         else
-          "#{stage.abbr} #{type[:key].to_s.upcase}"
+          stage ? "#{stage.abbr} #{type[:key].to_s.upcase}" : type[:key].to_s.upcase
         end
       end
 
@@ -346,7 +346,7 @@ module Pubid::Iso
         if self.class::TYPED_STAGES.key?(typed_stage)
           self.class::TYPED_STAGES[typed_stage][:name]
         else
-          "#{stage.name} #{type[:title]}"
+          stage ? "#{stage.name} #{type[:title]}" : type[:title]
         end
       end
 

--- a/lib/pubid/iso/identifier/international_standard.rb
+++ b/lib/pubid/iso/identifier/international_standard.rb
@@ -33,7 +33,7 @@ module Pubid::Iso
         if self.class::TYPED_STAGES.key?(typed_stage)
           super
         else
-          stage.abbr
+          stage&.abbr
         end
       end
 

--- a/spec/pubid_iso/identifier/create_new_identifier_spec.rb
+++ b/spec/pubid_iso/identifier/create_new_identifier_spec.rb
@@ -222,6 +222,14 @@ module Pubid::Iso
         it "should return IS class" do
           expect(subject).to be_a(Identifier::InternationalStandard)
         end
+
+        it "returns typed_stage_name" do
+          expect(subject.typed_stage_name).to eq("International Standard")
+        end
+
+        it "returns typed_stage_abbrev" do
+          expect(subject.typed_stage_abbrev).to eq(nil)
+        end
       end
 
       context "when have typed stage" do
@@ -274,6 +282,22 @@ module Pubid::Iso
 
           it "render DIR document with language" do
             expect(subject.to_s(format: :ref_num_long)).to eq("ISO DIR #{number}(en)")
+          end
+        end
+
+        context "when PRF stage" do
+          let(:params) { { type: :dir, stage: "PRF" }}
+
+          it "render DIR document" do
+            expect(subject.to_s).to eq("ISO DIR #{number}")
+          end
+
+          it "returns typed_stage_name" do
+            expect(subject.typed_stage_name).to eq("Proof of a new Directives")
+          end
+
+          it "returns typed_stage_abbrev" do
+            expect(subject.typed_stage_abbrev).to eq("PRF DIR")
           end
         end
       end


### PR DESCRIPTION
closes #135 