### PR TITLE
feat: Added transformation rules for part and number

### DIFF
--- a/lib/pubid/iso/parser.rb
+++ b/lib/pubid/iso/parser.rb
@@ -91,7 +91,6 @@ module Pubid::Iso
 
     rule(:year_digits) { (str("19") | str("20")) >> match('\d').repeat(2, 2) >> digits.absent? }
 
-
     rule(:part_matcher) do
       year_digits.absent? >>
         supplements.absent? >>

--- a/lib/pubid/iso/renderer/base.rb
+++ b/lib/pubid/iso/renderer/base.rb
@@ -156,8 +156,6 @@ module Pubid::Iso::Renderer
     end
 
     def render_part(part, opts, _params)
-      return "-#{part.reverse.join('-')}" if part.is_a?(Array)
-
       "-#{part}"
     end
 

--- a/lib/pubid/iso/transformer.rb
+++ b/lib/pubid/iso/transformer.rb
@@ -96,6 +96,18 @@ module Pubid::Iso
       { publisher: russian_publisher&.to_s || publisher }
     end
 
+    rule(part: simple(:part)) do
+      { part: part.to_s }
+    end
+
+    rule(part: sequence(:part)) do
+      { part: part.map(&:to_s).reverse.join("-") }
+    end
+
+    rule(number: simple(:number)) do
+      { number: number.to_s }
+    end
+
     rule(joint_document: subtree(:joint_document)) do |context|
       context[:joint_document] =
         Identifier.create(**context[:joint_document])
@@ -107,8 +119,6 @@ module Pubid::Iso
         Identifier::Base.transform(**(context[:dir_joint_document].merge(type: :dir)))
       context.select { |k, v| k != :dir_joint_document }
     end
-
-
 
     def self.convert_stage(code)
       russian_code = Pubid::Iso::Renderer::Base::TRANSLATION[:russian][:stage].key(code.to_s)

--- a/lib/pubid/iso/transformer.rb
+++ b/lib/pubid/iso/transformer.rb
@@ -96,16 +96,8 @@ module Pubid::Iso
       { publisher: russian_publisher&.to_s || publisher }
     end
 
-    rule(part: simple(:part)) do
-      { part: part.to_s }
-    end
-
     rule(part: sequence(:part)) do
       { part: part.map(&:to_s).reverse.join("-") }
-    end
-
-    rule(number: simple(:number)) do
-      { number: number.to_s }
     end
 
     rule(joint_document: subtree(:joint_document)) do |context|

--- a/spec/pubid_iso/identifier_parsing_spec.rb
+++ b/spec/pubid_iso/identifier_parsing_spec.rb
@@ -406,14 +406,6 @@ module Pubid::Iso
       end
     end
 
-    context "ISO 10303-1047-20-21:2014 ED3" do
-      let(:original) { "ISO 10303-1047-20-21:2014 ED3" }
-
-      it "returns part with dash" do
-        expect(subject.part).to eq("1047-20-21")
-      end
-    end
-
     context "ISO/IEC 17025:2005/Cor.1:2006(fr)" do
       let(:original) { "ISO/IEC 17025:2005/Cor.1:2006 ED1(fr)" }
       let(:pubid) { "ISO/IEC 17025:2005/Cor 1:2006(fr)" }
@@ -571,6 +563,10 @@ module Pubid::Iso
       let(:pubid) { "ISO/IEC/IEEE DTS 17301-1-1:2016(en)" }
 
       it_behaves_like "converts pubid to pubid"
+
+      it "returns part with dash" do
+        expect(subject.part).to eq("1-1")
+      end
     end
 
     context "ISO/IEC/IEEE FDTR 17301-1-1:2016(en)" do

--- a/spec/pubid_iso/identifier_parsing_spec.rb
+++ b/spec/pubid_iso/identifier_parsing_spec.rb
@@ -406,6 +406,14 @@ module Pubid::Iso
       end
     end
 
+    context "ISO 10303-1047-20-21:2014 ED3" do
+      let(:original) { "ISO 10303-1047-20-21:2014 ED3" }
+
+      it "returns part with dash" do
+        expect(subject.part).to eq("1047-20-21")
+      end
+    end
+
     context "ISO/IEC 17025:2005/Cor.1:2006(fr)" do
       let(:original) { "ISO/IEC 17025:2005/Cor.1:2006 ED1(fr)" }
       let(:pubid) { "ISO/IEC 17025:2005/Cor 1:2006(fr)" }


### PR DESCRIPTION
Added transformation rules for `part` and `number`, because the slices were being returned and causing issues in `stepmod-utils` as mentioned here -> https://github.com/glossarist/glossarist-ruby/issues/70