### PR TITLE
Add short (output) name for type, according to latest pubid-core changes

### DIFF
--- a/lib/pubid/iso/identifier/addendum.rb
+++ b/lib/pubid/iso/identifier/addendum.rb
@@ -13,7 +13,7 @@ module Pubid::Iso
         },
       }.freeze
       def self.type
-        { key: :add, title: "Addendum" }
+        { key: :add, title: "Addendum", short: "ADD" }
       end
 
       def self.get_renderer_class

--- a/lib/pubid/iso/identifier/amendment.rb
+++ b/lib/pubid/iso/identifier/amendment.rb
@@ -21,7 +21,7 @@ module Pubid::Iso
         },
       }.freeze
       def self.type
-        { key: :amd, title: "Amendment" }
+        { key: :amd, title: "Amendment", short: "AMD" }
       end
 
       def self.get_renderer_class

--- a/lib/pubid/iso/identifier/corrigendum.rb
+++ b/lib/pubid/iso/identifier/corrigendum.rb
@@ -22,7 +22,7 @@ module Pubid::Iso
       }.freeze
 
       def self.type
-        { key: :cor, title: "Corrigendum" }
+        { key: :cor, title: "Corrigendum", short: "COR" }
       end
 
       def self.get_renderer_class

--- a/lib/pubid/iso/identifier/directives.rb
+++ b/lib/pubid/iso/identifier/directives.rb
@@ -16,7 +16,7 @@ module Pubid::Iso
       end
 
       def self.type
-        { key: :dir, title: "Directives" }
+        { key: :dir, title: "Directives", short: "DIR" }
       end
 
       def self.get_renderer_class

--- a/lib/pubid/iso/identifier/extract.rb
+++ b/lib/pubid/iso/identifier/extract.rb
@@ -8,7 +8,7 @@ module Pubid::Iso
       TYPED_STAGES = {}.freeze
 
       def self.type
-        { key: :ext, title: "Extract" }
+        { key: :ext, title: "Extract", short: "EXT" }
       end
 
       def self.get_renderer_class

--- a/lib/pubid/iso/identifier/guide.rb
+++ b/lib/pubid/iso/identifier/guide.rb
@@ -25,7 +25,7 @@ module Pubid::Iso
       end
 
       def self.type
-        { key: :guide, title: "Guide" }
+        { key: :guide, title: "Guide", short: "GUIDE" }
       end
     end
   end

--- a/lib/pubid/iso/identifier/international_standard.rb
+++ b/lib/pubid/iso/identifier/international_standard.rb
@@ -39,7 +39,7 @@ module Pubid::Iso
       end
 
       def self.type
-        { key: :is, title: "International Standard" }
+        { key: :is, title: "International Standard", short: nil }
       end
     end
   end

--- a/lib/pubid/iso/identifier/international_standardized_profile.rb
+++ b/lib/pubid/iso/identifier/international_standardized_profile.rb
@@ -19,7 +19,7 @@ module Pubid::Iso
       }.freeze
 
       def self.type
-        { key: :isp, title: "International Standardized Profile" }
+        { key: :isp, title: "International Standardized Profile", short: "ISP" }
       end
 
       def self.get_renderer_class

--- a/lib/pubid/iso/identifier/international_workshop_agreement.rb
+++ b/lib/pubid/iso/identifier/international_workshop_agreement.rb
@@ -14,7 +14,7 @@ module Pubid::Iso
       }.freeze
 
       def self.type
-        { key: :iwa, title: "International Workshop Agreement" }
+        { key: :iwa, title: "International Workshop Agreement", short: "IWA" }
       end
 
       def self.get_renderer_class

--- a/lib/pubid/iso/identifier/publicly_available_specification.rb
+++ b/lib/pubid/iso/identifier/publicly_available_specification.rb
@@ -19,7 +19,7 @@ module Pubid::Iso
       }.freeze
 
       def self.type
-        { key: :pas, title: "Publicly Available Specification" }
+        { key: :pas, title: "Publicly Available Specification", short: "PAS" }
       end
 
       def self.get_renderer_class

--- a/lib/pubid/iso/identifier/recommendation.rb
+++ b/lib/pubid/iso/identifier/recommendation.rb
@@ -8,7 +8,7 @@ module Pubid::Iso
       TYPED_STAGES = {}.freeze
 
       def self.type
-        { key: :r, title: "Recommendation" }
+        { key: :r, title: "Recommendation", short: "R" }
       end
 
       def self.get_renderer_class

--- a/lib/pubid/iso/identifier/supplement.rb
+++ b/lib/pubid/iso/identifier/supplement.rb
@@ -24,7 +24,7 @@ module Pubid::Iso
       end
 
       def self.type
-        { key: :sup, title: "Supplement", values: %w[Supplement Suppl SUP] }
+        { key: :sup, title: "Supplement", values: %w[Supplement Suppl SUP], short: "SUP" }
       end
 
       def self.get_renderer_class

--- a/lib/pubid/iso/identifier/technical_committee.rb
+++ b/lib/pubid/iso/identifier/technical_committee.rb
@@ -8,7 +8,7 @@ module Pubid::Iso
       TYPED_STAGES = {}.freeze
 
       def self.type
-        { key: :tc, title: "Technical Committee" }
+        { key: :tc, title: "Technical Committee", short: "TC" }
       end
 
       def self.get_renderer_class

--- a/lib/pubid/iso/identifier/technical_report.rb
+++ b/lib/pubid/iso/identifier/technical_report.rb
@@ -19,7 +19,7 @@ module Pubid::Iso
       }.freeze
 
       def self.type
-        { key: :tr, title: "Technical Report" }
+        { key: :tr, title: "Technical Report", short: "TR" }
       end
 
       def self.get_renderer_class

--- a/lib/pubid/iso/identifier/technical_specification.rb
+++ b/lib/pubid/iso/identifier/technical_specification.rb
@@ -19,7 +19,7 @@ module Pubid::Iso
       }.freeze
 
       def self.type
-        { key: :ts, title: "Technical Specification" }
+        { key: :ts, title: "Technical Specification", short: "TS" }
       end
 
       def self.get_renderer_class

--- a/lib/pubid/iso/identifier/technology_trends_assessments.rb
+++ b/lib/pubid/iso/identifier/technology_trends_assessments.rb
@@ -19,7 +19,7 @@ module Pubid::Iso
       }.freeze
 
       def self.type
-        { key: :tta, title: "Technology Trends Assessments" }
+        { key: :tta, title: "Technology Trends Assessments", short: "TTA" }
       end
 
       def self.get_renderer_class

--- a/spec/pubid_iso/identifier/create_new_identifier_spec.rb
+++ b/spec/pubid_iso/identifier/create_new_identifier_spec.rb
@@ -57,14 +57,14 @@ module Pubid::Iso
         end
 
         context "when have document type" do
-          let(:params) { { stage: stage, type: :tr } }
+          let(:params) { { stage: stage, type: "TR" } }
 
           it "renders stage first" do
             expect(subject.to_s).to eq("ISO/WD TR #{number}")
           end
 
           it "returns type for #to_h" do
-            expect(subject.to_h[:type]).to eq(:tr)
+            expect(subject.to_h[:type]).to eq("TR")
           end
         end
 


### PR DESCRIPTION
closes #248 