### PR TITLE
Add UNDP ogranization to parse identifiers like "ISO/UNDP PAS 53002"

### DIFF
--- a/lib/pubid/iso/parser.rb
+++ b/lib/pubid/iso/parser.rb
@@ -43,7 +43,7 @@ module Pubid::Iso
       "CPAG", "CSC", "ITSAG", "CSC/FIN", "CSC/NOM", "CSC/OVE",
       "CSC/SP", "CSC/FIN", "JAG"].freeze
 
-    ORGANIZATIONS = %w[IEC IEEE CIW SAE CIE ASME ASTM OECD ISO HL7 CEI].freeze
+    ORGANIZATIONS = %w[IEC IEEE CIW SAE CIE ASME ASTM OECD ISO HL7 CEI UNDP].freeze
     rule(:dash) do
       str("-") | str("‑") | str("‐")
     end

--- a/spec/pubid_iso/identifier_parsing_spec.rb
+++ b/spec/pubid_iso/identifier_parsing_spec.rb
@@ -1046,5 +1046,11 @@ module Pubid::Iso
 
       it_behaves_like "converts pubid to pubid"
     end
+
+    context "ISO/UNDP PAS 53002" do
+      let(:pubid) { "ISO/UNDP PAS 53002" }
+
+      it_behaves_like "converts pubid to pubid"
+    end
   end
 end


### PR DESCRIPTION
closes #272 